### PR TITLE
fix (S3): Add support for S3 keys with slashes

### DIFF
--- a/auth/src/it/scala/auth/AwsSignerItSpec.scala
+++ b/auth/src/it/scala/auth/AwsSignerItSpec.scala
@@ -3,7 +3,6 @@ package auth
 
 import common._
 import common.model._
-
 import cats.effect.IO
 import org.http4s.client.Client
 import org.http4s.client.blaze.Http1Client
@@ -11,8 +10,8 @@ import cats.implicits._
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.Method._
-import org.http4s.Uri
-import org.http4s.client.middleware.{RequestLogger, ResponseLogger}
+import org.http4s.{Uri, Status}
+import org.http4s.client.middleware.{ResponseLogger, RequestLogger}
 
 import scala.concurrent.duration._
 
@@ -36,11 +35,31 @@ class AwsSignerItSpec extends IntegrationSpec with Http4sClientDsl[IO] {
           req <- GET(Uri.uri("https://s3-eu-west-1.amazonaws.com/ovo-comms-test/more.pdf"))
           status <- signedClient.status(req)
         } yield {
-          println(s"Status: $status")
           status.isSuccess shouldBe true
         }
       }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds))
     }
+
+    "sign request valid for S3 with nested paths" in {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service.S3)
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger.apply0[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger.apply0[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        for {
+          req <- GET(Uri.uri("https://s3-eu-west-1.amazonaws.com/ovo-comms-test/test/more.pdf"))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
+
   }
 
   def withHttpClient[A](f: Client[IO] => IO[A]): IO[A] = {

--- a/s3/src/main/scala/s3/S3.scala
+++ b/s3/src/main/scala/s3/S3.scala
@@ -53,9 +53,13 @@ class S3[F[_]: Sync](
     Uri.unsafeFromString(s"https://s3-${region.value}.amazonaws.com")
   }
 
-  // TODO It only supports path style access so far
   private def uri(bucket: Bucket, key: Key) = {
-    endpoint / bucket.name / key.value
+    // TODO It only supports path style access so far
+    val bucketEndpoint = endpoint / bucket.name
+
+    key.value.split("/", -1).foldLeft(bucketEndpoint) { (acc, x) =>
+      acc / x
+    }
   }
 
   private implicit val errorEntityDecoder: EntityDecoder[F, Error] =


### PR DESCRIPTION
Split the S3 key in all the parts between slashes, empty string included and add them to the http4s Uri.

Fixes: #9