### PR TITLE
Fix the AWS signature

### DIFF
--- a/auth/src/it/scala/auth/AwsSignerItSpec.scala
+++ b/auth/src/it/scala/auth/AwsSignerItSpec.scala
@@ -10,7 +10,8 @@ import cats.implicits._
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import org.http4s.client.dsl.Http4sClientDsl
 import org.http4s.Method._
-import org.http4s.{Uri, Status}
+import org.http4s.headers._
+import org.http4s.{Uri, Status, MediaType}
 import org.http4s.client.middleware.{ResponseLogger, RequestLogger}
 
 import scala.concurrent.duration._
@@ -18,6 +19,9 @@ import scala.concurrent.duration._
 class AwsSignerItSpec extends IntegrationSpec with Http4sClientDsl[IO] {
 
   implicit val ctx: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  // This is our UAT environment
+  private val esEndpoint = ""
 
   "AwsSigner" should {
     "sign request valid for S3" in {
@@ -34,7 +38,7 @@ class AwsSignerItSpec extends IntegrationSpec with Http4sClientDsl[IO] {
         val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
 
         for {
-          req <- GET(Uri.uri("https://s3-eu-west-1.amazonaws.com/ovo-comms-test/more.pdf"))
+          req <- GET(Uri.unsafeFromString("https://s3-eu-west-1.amazonaws.com/ovo-comms-test/more.pdf"))
           status <- signedClient.status(req)
         } yield {
           status.isSuccess shouldBe true
@@ -56,12 +60,212 @@ class AwsSignerItSpec extends IntegrationSpec with Http4sClientDsl[IO] {
         val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
 
         for {
-          req <- GET(Uri.uri("https://s3-eu-west-1.amazonaws.com/ovo-comms-test/test/more.pdf"))
+          req <- GET(Uri.unsafeFromString("https://s3-eu-west-1.amazonaws.com/ovo-comms-test/test/more.pdf"))
           status <- signedClient.status(req)
         } yield status
       }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
     }
 
+    "sign request valid for ES GET" ignore {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service("es"))
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        for {
+          req <- GET(Uri.unsafeFromString("${esEndpoint}/audit-2018-09/_doc/foo"))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
+
+    "sign request valid for ES POST" ignore {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service("es"))
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        val body = """
+        {
+          "query" : {
+            "term": {
+              "_id": "6fc53f9d-99a0-4938-a486-31fb401c5bc4"
+            }
+          }
+        }
+        """
+
+        for {
+          req <- POST(body, Uri.unsafeFromString("${esEndpoint}/audit-2018-09/_doc/_search"), `Content-Type`(MediaType.application.json))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
+
+    "sign request valid for ES POST with multiple indexes" ignore {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service("es"))
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        val body = """
+        {
+          "query" : {
+            "term": {
+              "_id": "6fc53f9d-99a0-4938-a486-31fb401c5bc4"
+            }
+          }
+        }
+        """
+
+        for {
+          req <- POST(body, Uri.unsafeFromString("${esEndpoint}/audit-2018-09,audit-2018-10,audit-2018-11/_doc/_search?ignore_unavailable=true"), `Content-Type`(MediaType.application.json))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
+
+    "sign request valid for ES POST with query" ignore {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service("es"))
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        val body = """
+        {
+          "query" : {
+            "term": {
+              "_id": "6fc53f9d-99a0-4938-a486-31fb401c5bc4"
+            }
+          }
+        }
+        """
+
+        for {
+          req <- POST(body, Uri.unsafeFromString("${esEndpoint}/audit-2018-09/_doc/_search?ignore_unavailable=true"), `Content-Type`(MediaType.application.json))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
+
+    "sign request valid for ES POST with query and multiple parameters" ignore {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service("es"))
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        val body = """
+        {
+          "query" : {
+            "term": {
+              "_id": "6fc53f9d-99a0-4938-a486-31fb401c5bc4"
+            }
+          }
+        }
+        """
+
+        for {
+          req <- POST(body, Uri.unsafeFromString("${esEndpoint}/audit-2018-09/_doc/_search?ignore_unavailable=true&refresh=true"), `Content-Type`(MediaType.application.json))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
+
+    "sign request valid for ES POST with query and multiple parameters with comas and stars" ignore {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service("es"))
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        val body = """
+        {
+          "query" : {
+            "term": {
+              "_id": "6fc53f9d-99a0-4938-a486-31fb401c5bc4"
+            }
+          }
+        }
+        """
+
+        for {
+          req <- POST(body, Uri.unsafeFromString("/audit-2018-09/_doc/_search?ignore_unavailable=true&refresh=true&foo*=foo&bar,baz=baz"), `Content-Type`(MediaType.application.json))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
+
+
+    "sign request valid for ES POST with star in path" ignore {
+      withHttpClient { client =>
+        val awsSigner = AwsSigner(
+          CredentialsProvider.fromAwsCredentialProvider[IO](
+            new DefaultAWSCredentialsProviderChain()),
+          Region.`eu-west-1`,
+          Service("es"))
+
+        val requestLogger: Client[IO] => Client[IO] = RequestLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+        val responseLogger: Client[IO] => Client[IO] = ResponseLogger[IO](logHeaders = true, logBody = true, redactHeadersWhen = _ => false)
+
+        val signedClient: Client[IO] = awsSigner(requestLogger(responseLogger(client)))
+
+        val body = """
+        {
+          "query" : {
+            "term": {
+              "_id": "6fc53f9d-99a0-4938-a486-31fb401c5bc4"
+            }
+          }
+        }
+        """
+
+        for {
+          req <- POST(body, Uri.unsafeFromString("${esEndpoint}/audit-*/_doc/_search"), `Content-Type`(MediaType.application.json))
+          status <- signedClient.status(req)
+        } yield status
+      }.futureValue(timeout(scaled(5.seconds)), interval(500.milliseconds)) should (not be Status.Unauthorized and not be Status.Forbidden)
+    }
   }
 
   def withHttpClient[A](f: Client[IO] => IO[A]): IO[A] = {

--- a/auth/src/main/scala/auth/AwsSigner.scala
+++ b/auth/src/main/scala/auth/AwsSigner.scala
@@ -270,8 +270,12 @@ object AwsSigner {
             // Normalize URI paths according to RFC 3986. Remove redundant and
             // relative path components. Each path segment must be URI-encoded
             // twice (except for Amazon S3 which only gets URI-encoded once).
+            //
+            // NOTE: This does not seems true at least not for ES
+            // TODO: Test against dynamodb
+            //
             val encodedTwiceSegments = if (service != Service.S3) {
-              encodedOnceSegments.map(uriEncode)
+              encodedOnceSegments
             } else {
               encodedOnceSegments
             }

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val scalatestVersion = "3.0.5"
 lazy val scalacheckVersion = "1.14.0"
 lazy val slf4jVersion = "1.7.25"
 lazy val log4jVersion = "2.11.1"
-lazy val http4sVersion = "0.20.0-M4"
+lazy val http4sVersion = "0.20.0-M5"
 lazy val commsDockerkitVersion = "1.8.6"
 lazy val scalaXmlVersion = "1.1.1"
 

--- a/common/src/it/resources/log4j2-it.xml
+++ b/common/src/it/resources/log4j2-it.xml
@@ -6,6 +6,7 @@
         </File>
     </Appenders>
     <Loggers>
+        <logger name="com.ovoenergy.comms.aws.auth" level="DEBUG" />
         <Root level="INFO">
             <AppenderRef ref="File"/>
         </Root>


### PR DESCRIPTION
Remove the double encoding from the path as it does not seems to work in Elasticsearch at least.