### PR TITLE
Fix deprecations

### DIFF
--- a/modules/auth/src/main/scala/auth/AwsSigner.scala
+++ b/modules/auth/src/main/scala/auth/AwsSigner.scala
@@ -283,7 +283,7 @@ object AwsSigner {
           // relative path components. Each path segment must be URI-encoded
           // twice (except for Amazon S3 which only gets URI-encoded once).
           //
-          // NOTE: This does not seems true at least not for ES
+          // NOTE: This does not seem true at least not for ES
           // TODO: Test against dynamodb
           //
           val encodedTwiceSegments = if (service != Service.S3) {

--- a/modules/common/src/it/scala/common/IntegrationSpec.scala
+++ b/modules/common/src/it/scala/common/IntegrationSpec.scala
@@ -1,9 +1,10 @@
 package com.ovoenergy.comms.aws
 package common
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-abstract class IntegrationSpec extends WordSpec with Matchers with IOFutures {
+abstract class IntegrationSpec extends AnyWordSpec with Matchers with IOFutures {
   sys.props.put("log4j.configurationFile", "log4j2-it.xml")
 }
 

--- a/modules/s3/src/main/scala/s3/S3.scala
+++ b/modules/s3/src/main/scala/s3/S3.scala
@@ -80,7 +80,7 @@ object S3 {
     val signedClient = signer(client)
     val baseEndpoint = endpoint.getOrElse {
       if (region == Region.`us-east-1`)
-        Uri.uri("https://s3.amazonaws.com")
+        uri"https://s3.amazonaws.com"
       else
         Uri.unsafeFromString(s"https://s3-${region.value}.amazonaws.com")
       // TODO use the total version, we may need a S3 builder that returns F[S3[F]]


### PR DESCRIPTION
This is how I ran the tests.

```
sbt> test
[info] AwsSignV4TestSuiteSpec:
[info] AwsSigner
[info] - should pass test case 'get-vanilla-query-order-key-case'
[info] - should pass test case 'get-header-value-trim'
[info] - should pass test case 'post-header-key-case'
[info] - should pass test case 'post-header-key-sort'
[info] - should pass test case 'get-header-value-order'
[info] - should pass test case 'post-vanilla'
[info] - should pass test case 'get-slash'
[info] - should pass test case 'post-sts-header-after'
[info] - should pass test case 'get-vanilla'
[info] - should pass test case 'post-vanilla-empty-query-value'
[info] - should pass test case 'get-header-key-duplicate'
[info] - should pass test case 'get-vanilla-query'
[info] - should pass test case 'post-vanilla-query'
[info] - should pass test case 'post-sts-header-before'
[info] - should pass test case 'get-vanilla-empty-query-key'
[info] - should pass test case 'post-header-value-case'
[info] AwsSignerSpec:
[info] digest
[info] - should calculate the correct digest
[info]   + Expected empty body hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 
[info] - should calculate the correct digest for empty body
[info] Request with no body
[info] - should not have empty body stream
[info] uriEncoder
[info] - should encode :
[info] - should encode %2F
[info] AwsSigner.fixRequest
[info]   when Date header is not defined
[info]     when X-Amz-Date is not defined
[info]     - should Add X-Amz-Date
[info]     when X-Amz-Date is defined
[info]     - should not add X-Amz-Date
[info]   when Date header is defined
[info]   - should not add X-Amz-Date
[info]   when Host header is defined
[info]     when the uri is absolute
[info]     - should not add Host header
[info]     when the uri is relative
[info]     - should fail the effect
[info]   when Credentials contain the session token
[info]   - should add the X-Amz-Security-Token header
[info]   when Credentials do not contain the session token
[info]   - should not add the X-Amz-Security-Token header
[info] AwsSigner.signRequest
[info]   when Date header is not defined
[info]     when X-Amz-Date is not defined
[info]     - should return a failed effect
[info] AwsSigner.signRequest
[info] - should sign a vanilla GET request correctly
[info] - should sign a vanilla POST request correctly
[info] - should sign a POST request with body
[info] ScalaTest
[info] Run completed in 1 second, 192 milliseconds.
[info] Total number of tests run: 32
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 32, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 32, Failed 0, Errors 0, Passed 32
[success] Total time: 8 s, completed 19 May 2020, 16:36:15
```

