### PR TITLE
Use sbt-release-tags-only to publish to artifactory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
         at: .
     - restore_sbt_cache
     - run:
-        command: sbt +releaseEarly
+        command: sbt +publish
         no_output_timeout: 20m
 
 workflows:
@@ -277,42 +277,58 @@ workflows:
   main:
     jobs:
     - snyk_test:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         filters:
           branches:
             only:
                 - master
 
     - build:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
 
     - auth_unit_test:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         requires:
         - build
 
     - common_unit_test:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         requires:
         - build
     
     - s3_unit_test:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         requires:
         - build
 
     - auth_integration_test:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         requires:
         - build
 
     - common_integration_test:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         requires:
         - build
     
     - s3_integration_test:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         requires:
         - build
 
@@ -331,7 +347,9 @@ workflows:
             only: master
 
     - release:
-        context: ovo-internal-public
+        context:
+          - ovo-internal-public
+          - comms-internal-build
         requires:
         - tag
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,7 @@
+import sbtrelease.ExtraReleaseCommands
+import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.tagsonly.TagsOnly._
+
 lazy val fs2Version = "2.5.3"
 lazy val catsEffectVersion = "2.0.0"
 lazy val catsVersion = "2.0.0"
@@ -21,29 +25,29 @@ lazy val noPublishSettings = Seq(
   publishArtifact := false
 )
 
-lazy val releaseOptions = Seq(
-  releaseEarlyWith := BintrayPublisher,
-  releaseEarlyEnableSyncToMaven := false,
-  releaseEarlyNoGpg := true,
-  //  releaseEarlyEnableSyncToMaven := false,
-  bintrayOrganization := Some("ovotech"),
-  bintrayRepository := "maven",
-  bintrayPackageLabels := Seq(
-    "aws",
-    "cats",
-    "cats-effect",
-    "http4s",
-    "fs2",
-    "scala"
-  ),
-  version ~= (_.replace('+', '-')),
-  dynver ~= (_.replace('+', '-'))
+lazy val publishOptions = Seq(
+  publishTo := Some("Artifactory Realm" at "https://kaluza.jfrog.io/artifactory/maven"),
+  credentials += {
+    for {
+      usr <- sys.env.get("ARTIFACTORY_USER")
+      password <- sys.env.get("ARTIFACTORY_PASS")
+    } yield Credentials("Artifactory Realm", "kaluza.jfrog.io", usr, password)
+  }.getOrElse(Credentials(Path.userHome / ".ivy2" / ".credentials")),
+  releaseProcess := Seq[ReleaseStep](
+    checkSnapshotDependencies,
+    releaseStepCommand(ExtraReleaseCommands.initialVcsChecksCommand),
+    setVersionFromTags(releaseTagPrefix.value),
+    runClean,
+    tagRelease,
+    publishArtifacts,
+    pushTagsOnly
+  )
 )
 
 lazy val root = (project in file("."))
   .aggregate(auth, common, s3)
   .configs(IntegrationTest)
-  .settings(releaseOptions)
+  .settings(publishOptions)
   .settings(
     name := "comms-aws",
     inThisBuild(
@@ -89,7 +93,7 @@ lazy val root = (project in file("."))
         scalaVersion := "2.13.2",
         crossScalaVersions += "2.12.10",
         resolvers ++= Seq(
-          Resolver.bintrayRepo("ovotech", "maven")
+          "Artifactory" at "https://kaluza.jfrog.io/artifactory/maven",
         ),
         libraryDependencies ++= Seq(
           "org.http4s" %% "http4s-core" % http4sVersion,
@@ -114,7 +118,7 @@ lazy val root = (project in file("."))
 lazy val common = (project in file("modules/common"))
   .enablePlugins(AutomateHeaderPlugin)
   .configs(IntegrationTest)
-  .settings(releaseOptions)
+  .settings(publishOptions)
   .settings(
     name := "comms-aws-common",
     scalacOptions -= "-Xfatal-warnings" // enable all options from sbt-tpolecat except fatal warnings
@@ -132,7 +136,7 @@ lazy val auth = (project in file("modules/auth"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(common % s"$Compile->$Compile;$Test->$Test;$IntegrationTest->$IntegrationTest")
   .configs(IntegrationTest)
-  .settings(releaseOptions)
+  .settings(publishOptions)
   .settings(
     name := "comms-aws-auth",
     scalacOptions -= "-Xfatal-warnings" // enable all options from sbt-tpolecat except fatal warnings
@@ -150,7 +154,7 @@ lazy val s3 = (project in file("modules/s3"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(common % s"$Compile->$Compile;$Test->$Test;$IntegrationTest->$IntegrationTest", auth)
   .configs(IntegrationTest)
-  .settings(releaseOptions)
+  .settings(publishOptions)
   .settings(
     name := "comms-aws-s3",
     scalacOptions -= "-Xfatal-warnings" // enable all options from sbt-tpolecat except fatal warnings

--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,10 @@ lazy val noPublishSettings = Seq(
   publishArtifact := false
 )
 
+lazy val publicArtifactory = "Artifactory Realm" at "https://kaluza.jfrog.io/artifactory/maven"
+
 lazy val publishOptions = Seq(
-  publishTo := Some("Artifactory Realm" at "https://kaluza.jfrog.io/artifactory/maven"),
+  publishTo := Some(publicArtifactory),
   credentials += {
     for {
       usr <- sys.env.get("ARTIFACTORY_USER")
@@ -93,7 +95,7 @@ lazy val root = (project in file("."))
         scalaVersion := "2.13.2",
         crossScalaVersions += "2.12.10",
         resolvers ++= Seq(
-          "Artifactory" at "https://kaluza.jfrog.io/artifactory/maven",
+          publicArtifactory,
         ),
         libraryDependencies ++= Seq(
           "org.http4s" %% "http4s-core" % http4sVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("ch.epfl.scala" % "sbt-release-early" % "2.1.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addSbtPlugin("fr.qux" % "sbt-release-tags-only" % "0.5.0")
+
+resolvers += Resolver.sonatypeRepo("releases")


### PR DESCRIPTION
- We use sbt-release-early plugin for our libraries right now. It only supports bintray and sonatype.
- I am switching to use this sbt-release-tags-only plugin https://github.com/dimitriho/sbt-release-tags-only
- It is an extension of stb-release
- It allows cross publishing and uses git tags for versioning (which is what we need).